### PR TITLE
Add support for children in GEditor

### DIFF
--- a/src/components/GEditor.tsx
+++ b/src/components/GEditor.tsx
@@ -22,6 +22,7 @@ interface IProps {
   storageManager: IStorageManager;
   blockManager: {};
   styleManager: IStyleManager;
+  children?: any;
 }
 
 function GEditor(props: IProps) {
@@ -32,7 +33,8 @@ function GEditor(props: IProps) {
     components,
     blocks,
     webpage,
-    newsletter
+    newsletter,
+    children
   } = props;
 
   const [editor, setEditor] = useState(null);
@@ -100,7 +102,7 @@ function GEditor(props: IProps) {
     []
   );
 
-  return <div id={id}/>;
+  return <div id={id}>{children ? children : null}</div>;
 }
 
 GEditor.defaultProps = {

--- a/src/components/GEditor.tsx
+++ b/src/components/GEditor.tsx
@@ -102,7 +102,11 @@ function GEditor(props: IProps) {
     []
   );
 
-  return <div id={id}>{children ? children : null}</div>;
+  return (
+      <div id={id}>
+          {children}
+      </div>
+  );
 }
 
 GEditor.defaultProps = {

--- a/src/example/EditorMounting.tsx
+++ b/src/example/EditorMounting.tsx
@@ -20,7 +20,7 @@ function EditorMounting() {
           {mounted ? 'Unmount' : 'Mount'}
         </Button>
       </div>
-      <div>{mounted && <GEditor id="geditor" newsletter={true}/>}</div>
+        <div>{mounted && <GEditor id="geditor" newsletter={true}><div>Drag some elements!</div></GEditor>}</div>
     </div>
   );
 }


### PR DESCRIPTION
This allows providing the initial content of the editor.

See issue #16