### PR TITLE
onInit receives current editor

### DIFF
--- a/src/Editor/Editor.tsx
+++ b/src/Editor/Editor.tsx
@@ -96,7 +96,7 @@ const Editor = React.forwardRef(
           });
           setEditor(newEditor);
           if (onInit) {
-            onInit(editor);
+            onInit(newEditor);
           }
         }
         return handleCleanup;


### PR DESCRIPTION
onInit was being called with the empty version of the editor.