### PR TITLE
Update ReadMe to take account into grapejs css; and the way plugins a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ _A React wrapper library for [GrapesJS](https://grapesjs.com)_
 ## Installation
 
 ```shell
-npm i -S grapesjs grapesjs-react
+npm i -S grapesjs grapesjs-react grapesjs-blocks-basic
 ```
 
 or
 
 ```shell
-yarn add grapesjs grapesjs-react
+yarn add grapesjs grapesjs-react grapesjs-blocks-basic
 ```
 
 ## Usage
@@ -23,14 +23,16 @@ yarn add grapesjs grapesjs-react
 You need to install the [grapesjs-preset-webpage](https://www.npmjs.com/package/grapesjs-preset-webpage) plugin
 
 ```tsx
-import 'grapesjs-preset-webpage';
+import 'grapesjs/dist/css/grapes.min.css';
+import gjspresetwebpage from 'grapesjs-preset-webpage';
+import gjsblockbasic from 'grapesjs-blocks-basic'
 
 export const Primary = () => {
   return <GrapesjsReact
     id='grapesjs-react'
     plugins={[
-      'gjs-preset-webpage',
-      'gjs-blocks-basic'
+      gjspresetwebpage,
+      gjsblockbasic
     ]}
   />;
 };
@@ -41,14 +43,16 @@ export const Primary = () => {
 You need to install the [grapesjs-preset-newsletter](https://www.npmjs.com/package/grapesjs-preset-newsletter) plugin
 
 ```tsx
-import 'grapesjs-preset-newsletter';
+import 'grapesjs/dist/css/grapes.min.css';
+import gjsblockbasic from 'grapesjs-blocks-basic'
+import gjspresetnewsletter from 'grapesjs-preset-newsletter';
 
 export const Newsletter = () => {
   return <GrapesjsReact
     id='grapesjs-react'
     plugins={[
-      'gjs-preset-newsletter',
-      'gjs-blocks-basic'
+      gjsblockbasic, 
+      gjspresetnewsletter
     ]}
   />;
 };
@@ -59,14 +63,16 @@ export const Newsletter = () => {
 You need to install the [grapesjs-mjml](https://www.npmjs.com/package/grapesjs-mjml) plugin
 
 ```tsx
-import 'grapesjs-mjml';
+import 'grapesjs/dist/css/grapes.min.css';
+import gjsblockbasic from 'grapesjs-blocks-basic'
+import gjsmjml from 'grapesjs-mjml';
 
 export const MJML = () => {
   return <GrapesjsReact
     id='grapesjs-react'
     plugins={[
-      'grapesjs-mjml',
-      'gjs-blocks-basic'
+      gjsblockbasic,
+      gjsmjml
     ]}
   />;
 };


### PR DESCRIPTION
Update ReadMe to take account into grapejs css; and the way plugins are imported to be used in React.

Reason: When I was using the Library, I realized that CSS was not working as expected and I realized like in the `ReadMe` there is nothing mentioned about the default editor CSS. Also, the plugins were not working, was getting a warning and they were not loading. So I changed the way they are being loaded and updated the ReadMe accordingly.